### PR TITLE
Поддержка предворительных релизов на уровне сборки

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Run Cake script
         uses: cake-build/cake-action@v1
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Run Cake script
         uses: cake-build/cake-action@v1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Run Cake script
         uses: cake-build/cake-action@v1
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Run Cake script
         uses: cake-build/cake-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,12 @@
 name: release
+
 on:
   release:
     types: [published]
-    branches:
-      - master
-jobs:
-  test:
-    name: test
-
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
     
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
-      - name: Run Cake script
-        uses: cake-build/cake-action@v1
-        with:
-          script-path: ./build/build.cake
-          target: Test
-          verbosity: Verbose
-          arguments: |
-            configuration: Release
-            nuget_useinprocessclient: true
-            settings_skipverification: true
-            settings_skippackageversioncheck: true
+jobs:
   deploy:
     name: deploy
-    needs: test
 
     runs-on: ubuntu-latest
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Run Cake script
         uses: cake-build/cake-action@v1
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.1</Version>
+	<VersionPrefix>0.0.1</VersionPrefix>
     <AssemblyName>Byndyusoft.Net.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>Byndyusoft.Net.$(MSBuildProjectName)</RootNamespace>
     <Authors>Byndyusoft</Authors>

--- a/build/build.cake
+++ b/build/build.cake
@@ -148,7 +148,7 @@ Task("CalculateCoverage")
 
 // Run dotnet pack to produce NuGet packages from our projects.
 Task("Pack")
-    .IsDependentOn("Build")
+    .IsDependentOn("Test")
     .Does(() =>
     {
         var settings = new DotNetPackSettings

--- a/build/build.cake
+++ b/build/build.cake
@@ -2,6 +2,8 @@
 #addin "nuget:?package=Cake.Coverlet"
 
 using System.Linq;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 // Target - The task you want to start. Runs the Default task if not specified.
 var target = Argument("Target", "Default");
@@ -13,6 +15,51 @@ var configuration =
     HasArgument("Configuration") 
         ? Argument<string>("Configuration") 
         : EnvironmentVariable("Configuration") ?? "Release";
+		
+// The build number to use in the version number of the built NuGet packages.
+// There are multiple ways this value can be passed, this is a common pattern.
+var buildNumber =
+    HasArgument("BuildNumber") ? Argument<int>("BuildNumber") :
+    EnvironmentVariable("BuildNumber") != null ? int.Parse(EnvironmentVariable("BuildNumber")) : 
+    AppVeyor.IsRunningOnAppVeyor ? AppVeyor.Environment.Build.Number :
+    TravisCI.IsRunningOnTravisCI ? TravisCI.Environment.Build.BuildNumber :
+    GitHubActions.IsRunningOnGitHubActions ? int.Parse(EnvironmentVariable("GITHUB_RUN_NUMBER")) :
+    0;
+
+// Branch or tag name used in version suffix and packages info
+var refName = 
+    AppVeyor.IsRunningOnAppVeyor ? (AppVeyor.Environment.Repository.Tag.IsTag ? AppVeyor.Environment.Repository.Tag.Name : AppVeyor.Environment.Repository.Branch) :
+    TravisCI.IsRunningOnTravisCI ? TravisCI.Environment.Build.Branch : 
+    GitHubActions.IsRunningOnGitHubActions ? EnvironmentVariable("GITHUB_REF_NAME") :
+    (string)null;
+// The type of ref that triggered build. Valid values are branch or tag
+var refType = 
+    AppVeyor.IsRunningOnAppVeyor ? (AppVeyor.Environment.Repository.Tag.IsTag ? "tag" : "branch") :
+    TravisCI.IsRunningOnTravisCI ? (string.IsNullOrWhiteSpace(TravisCI.Environment.Build.Tag) == false ? "tag" : "branch") : 
+    GitHubActions.IsRunningOnGitHubActions ? EnvironmentVariable("GITHUB_REF_TYPE") :
+    (string)null;
+// Commit Id for packages info
+var commitId =
+    AppVeyor.IsRunningOnAppVeyor ? AppVeyor.Environment.Repository.Commit.Id :
+    TravisCI.IsRunningOnTravisCI ? TravisCI.Environment.Repository.Commit : 
+    GitHubActions.IsRunningOnGitHubActions ? EnvironmentVariable("GITHUB_SHA") :
+    (string)null;
+
+// Text suffix of the package version
+string versionSuffix = null;
+switch (refType)
+{
+    case "tag":
+        var match = Regex.Match(refName, "v\\d+\\.\\d+\\.\\d+\\-?(.*)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        if(match.Success == false)
+            versionSuffix = refName;
+        else if(string.IsNullOrWhiteSpace(match.Groups[1].Value) == false)
+            versionSuffix = match.Groups[1].Value;
+        break;
+    case "branch":
+        versionSuffix = $"{refName.Replace("/", "-", true, System.Globalization.CultureInfo.InvariantCulture)}-build{buildNumber:00000}";
+        break;
+}
 
 // A directory path to an Artifacts directory.
 var artifactsDirectory = MakeAbsolute(Directory("./artifacts"));
@@ -32,14 +79,17 @@ Task("Clean")
     .IsDependentOn("Clean")
     .Does(() =>
     {
-        DotNetBuild(
-            "..", 
-            new DotNetBuildSettings
-            {
-                Configuration = configuration,
-                ArgumentCustomization = args => args.Append("--configfile ./NuGet.config")
-            }
-        );
+        var settings =  new DotNetBuildSettings
+                {
+                    Configuration = configuration,
+                    VersionSuffix = versionSuffix,
+                    ArgumentCustomization = args => args.Append("--configfile ./NuGet.config")
+                };
+
+        if(buildNumber != 0)
+            settings.MSBuildSettings = new DotNetMSBuildSettings {Properties = { {"Build", new[] {buildNumber.ToString()}}}};
+
+        DotNetBuild("..", settings);
     });
 
 // Look under a 'Tests' folder and run dotnet test against all of those projects.
@@ -101,22 +151,24 @@ Task("Pack")
     .IsDependentOn("Build")
     .Does(() =>
     {
-        DotNetPack(
-            "..", 
-            new DotNetPackSettings
-            {
-                Configuration = configuration,
-                NoRestore = true,
-                NoBuild = true,
-                OutputDirectory = artifactsDirectory,
-                IncludeSymbols = true,
-                MSBuildSettings 
-                    = new DotNetMSBuildSettings
-                      {
-                          Properties = { {"SymbolPackageFormat", new[] {"snupkg"} } }
-                      }
-            }
-        );
+        var settings = new DotNetPackSettings
+                {
+                    Configuration = configuration,
+                    NoRestore = true,
+                    NoBuild = true,
+                    OutputDirectory = artifactsDirectory,
+                    IncludeSymbols = true,
+                    VersionSuffix = versionSuffix,
+                    MSBuildSettings = new DotNetMSBuildSettings {Properties = { {"SymbolPackageFormat", new[] {"snupkg"} } }}
+                };
+				
+        if(string.IsNullOrWhiteSpace(versionSuffix) == false)
+        {
+            settings.MSBuildSettings.Properties["RepositoryRefName"] = new[] {refName};
+            settings.MSBuildSettings.Properties["RepositoryCommit"] = new[] {commitId};
+        }
+
+        DotNetPack("..", settings);
     });
 
 // The default task to run if none is explicitly specified. In this case, we want

--- a/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
+++ b/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
@@ -1,7 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<Description>RabbitMQ API extensions</Description>
+	<PackageDescription Condition="'$(VersionSuffix)'!=''">
+	  $(Description)
+	  Reference name: $(RepositoryRefName)
+	  Working tree: $(RepositoryUrl)/tree/$(RepositoryCommit)
+	</PackageDescription>
+	<TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
+++ b/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
@@ -7,7 +7,7 @@
 	  Reference name: $(RepositoryRefName)
 	  Working tree: $(RepositoryUrl)/tree/$(RepositoryCommit)
 	</PackageDescription>
-	<TargetFramework>net5.0</TargetFramework>
+	<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
+++ b/src/RabbitMq.Extensions/RabbitMq.Extensions.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Byndyusoft.Metrics" Version="1.0.0" />
-    <PackageReference Include="Jaeger" Version="1.0.2" />
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
     <PackageReference Include="prometheus-net" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/RabbitMq/RabbitMq.csproj
+++ b/src/RabbitMq/RabbitMq.csproj
@@ -16,12 +16,9 @@
     <PackageReference Include="easynetq" Version="5.6.0" />
     <PackageReference Include="fluentassertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
   </ItemGroup>
 

--- a/src/RabbitMq/RabbitMq.csproj
+++ b/src/RabbitMq/RabbitMq.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<Description>Yet another .NET API for RabbitMQ</Description>
+	<PackageDescription Condition="'$(VersionSuffix)'!=''">
+	  $(Description)
+	  Reference name: $(RepositoryRefName)
+	  Working tree: $(RepositoryUrl)/tree/$(RepositoryCommit)
+	</PackageDescription>
+	<TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/RabbitMq/RabbitMq.csproj
+++ b/src/RabbitMq/RabbitMq.csproj
@@ -7,19 +7,19 @@
 	  Reference name: $(RepositoryRefName)
 	  Working tree: $(RepositoryUrl)/tree/$(RepositoryCommit)
 	</PackageDescription>
-	<TargetFramework>net5.0</TargetFramework>
+	<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="easynetq" Version="5.6.0" />
-    <PackageReference Include="fluentassertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="fluentassertions" Version="6.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.22" />
     <PackageReference Include="moq" Version="4.16.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/RabbitMq.Tests/RabbitMq.Tests.csproj
+++ b/tests/RabbitMq.Tests/RabbitMq.Tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>    
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Jaeger" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Jaeger" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RabbitMq.Tests/RabbitMq.Tests.csproj
+++ b/tests/RabbitMq.Tests/RabbitMq.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>    
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Jaeger" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Изменения:
1.  Автоматическая простановка суффикса версии из тэга репозитория;
2. Сборка предворительных релизов поддерживается из любых веток;
3. Для предворительных релизов в описание пакета добавляется ссылка на состояние репозитория.